### PR TITLE
Fix build errors on declaration within switch case

### DIFF
--- a/i2c_peripheral.c
+++ b/i2c_peripheral.c
@@ -269,24 +269,30 @@ void i2c_task() {
             
             switch (next_adc_channel) {
                 case 0:
+                {
                     uint16_t* reg_vusb = (uint16_t*) &i2c_registers.registers[I2C_REGISTER_ADC_VALUE_VUSB_LO];
                     adc_select_input(ANALOG_VUSB_ADC);
                     *reg_vusb = adc_read();
                     next_adc_channel = 1;
                     break;
+                }
                 case 1:
+                {
                     uint16_t* reg_vbat = (uint16_t*) &i2c_registers.registers[I2C_REGISTER_ADC_VALUE_VBAT_LO];
                     adc_select_input(ANALOG_VBAT_ADC);
                     *reg_vbat = adc_read();
                     next_adc_channel = 2;
                     break;
+                }
                 case 2:
                 default:
+                {
                     uint16_t* reg_temp = (uint16_t*) &i2c_registers.registers[I2C_REGISTER_ADC_VALUE_TEMP_LO];
                     adc_select_input(ANALOG_TEMP_ADC);
                     *reg_temp = adc_read();
                     next_adc_channel = 0;
                     break;
+                }
             }
         }
     }


### PR DESCRIPTION
```
Scanning dependencies of target mch2022_firmware
[ 52%] Building C object CMakeFiles/mch2022_firmware.dir/main.c.obj
[ 53%] Building C object CMakeFiles/mch2022_firmware.dir/usb_descriptors.c.obj
[ 54%] Building C object CMakeFiles/mch2022_firmware.dir/uart_task.c.obj
[ 54%] Building C object CMakeFiles/mch2022_firmware.dir/lcd.c.obj
[ 55%] Building C object CMakeFiles/mch2022_firmware.dir/i2c_peripheral.c.obj
/home/reinier/code/badgeteam/mch2022-firmware-rp2040/i2c_peripheral.c: In function 'i2c_task':
/home/reinier/code/badgeteam/mch2022-firmware-rp2040/i2c_peripheral.c:272:21: error: a label can only be part of a statement and a declaration is not a statement
  272 |                     uint16_t* reg_vusb = (uint16_t*) &i2c_registers.registers[I2C_REGISTER_ADC_VALUE_VUSB_LO];
      |                     ^~~~~~~~
/home/reinier/code/badgeteam/mch2022-firmware-rp2040/i2c_peripheral.c:278:21: error: a label can only be part of a statement and a declaration is not a statement
  278 |                     uint16_t* reg_vbat = (uint16_t*) &i2c_registers.registers[I2C_REGISTER_ADC_VALUE_VBAT_LO];
      |                     ^~~~~~~~
/home/reinier/code/badgeteam/mch2022-firmware-rp2040/i2c_peripheral.c:285:21: error: a label can only be part of a statement and a declaration is not a statement
  285 |                     uint16_t* reg_temp = (uint16_t*) &i2c_registers.registers[I2C_REGISTER_ADC_VALUE_TEMP_LO];
      |                     ^~~~~~~~
make[3]: *** [CMakeFiles/mch2022_firmware.dir/build.make:132: CMakeFiles/mch2022_firmware.dir/i2c_peripheral.c.obj] Error 1
make[2]: *** [CMakeFiles/Makefile2:1402: CMakeFiles/mch2022_firmware.dir/all] Error 2
make[1]: *** [Makefile:91: all] Error 2
make: *** [Makefile:20: build] Error 2
```
There are two possible (syntactical) fixes for this: adding curly braces (like this PR) or adding a semicolon after the `case` label. I think this is the cleaner option.

Moving the declaration out of the switch case would also fix the issue.