### PR TITLE
Add custom panic handler

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -70,6 +70,13 @@ add_executable(${NAME}
     i2c_peripheral.c
 )
 
+if (CMAKE_BUILD_TYPE STREQUAL "Debug")
+    message("Debug mode: using default panic handler")
+else ()
+    message("Release mode: using custom panic handler")
+    target_compile_definitions(${NAME} PUBLIC PICO_PANIC_FUNCTION=custom_panic)
+endif ()
+
 target_include_directories(${NAME} PUBLIC
         ${CMAKE_CURRENT_LIST_DIR})
 

--- a/i2c_peripheral.c
+++ b/i2c_peripheral.c
@@ -325,3 +325,7 @@ void i2c_set_webusb_mode(uint8_t mode) {
     webusb_mode = mode;
     //webusb_interrupt = true;
 }
+
+void i2c_set_crash_debug_state(bool crashed, bool debug) {
+    i2c_registers.registers[I2C_REGISTER_CRASH_DEBUG] = (crashed & 1) | ((debug << 1) & 2);
+}

--- a/i2c_peripheral.h
+++ b/i2c_peripheral.h
@@ -19,6 +19,8 @@ void i2c_usb_set_suspended(bool suspended, bool remote_wakeup_en);
 
 void i2c_set_webusb_mode(uint8_t mode);
 
+void i2c_set_crash_debug_state(bool crashed, bool debug);
+
 enum {
     // 0-7
     I2C_REGISTER_FW_VER,
@@ -43,7 +45,7 @@ enum {
     // 16-23
     I2C_REGISTER_BL_TRIGGER,
     I2C_REGISTER_WEBUSB_MODE,
-    I2C_REGISTER_RESERVED1,
+    I2C_REGISTER_CRASH_DEBUG,
     I2C_REGISTER_RESERVED2,
     I2C_REGISTER_RESERVED3,
     I2C_REGISTER_CHARGING_STATE,


### PR DESCRIPTION
(ESP32 side not done yet so I still have to test if it works properly)

The idea here is that if a call to panic() is made the RP2040 will reboot and set a register accessible over I2C that indicates it has crashed.

SDK behaviour of panic() is to print ***** PANIC ***** with a reason to the UART then halt, that's not very usefull on the badge.

When the RP2040 crashes and reboots it resets the ESP32 too, so checking the register on startup and showing a message to the user indicating the reason for rebooting would help identify RP2040 problems on production firmware.

When compiled in debug mode the panic handler isn't modified so that crashes can be investigated with a JTAG debugger.